### PR TITLE
Add missing option `processor`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -78,6 +78,12 @@ export interface EslintConfig {
    * @see [Settings](https://eslint.org/docs/user-guide/configuring/configuration-files#adding-shared-settings)
    */
   settings?: Settings;
+  /**
+   * Specifying Processor.
+   *
+   * @see [processor](https://eslint.org/docs/user-guide/configuring/plugins#specifying-processor)
+   */
+  processor?: string;
 }
 
 /**

--- a/src/overrides.d.ts
+++ b/src/overrides.d.ts
@@ -25,6 +25,12 @@ export interface Override {
    * @see [Rules](https://eslint.org/docs/user-guide/configuring/rules)
    */
   rules?: Rules;
+  /**
+   * Specifying Processor.
+   *
+   * @see [processor](https://eslint.org/docs/user-guide/configuring/plugins#specifying-processor)
+   */
+  processor?: string;
 }
 
 /**


### PR DESCRIPTION
Hi!

Thank you for this very helpful tool. I was using it when configuring my own shareable ESLint configuration.
I noticed the errors while configuring for example [`eslint-plugin-svelte3`](https://github.com/sveltejs/eslint-plugin-svelte3#configuration), where I had to specify the `processor` option.

---

ESLint allows specifying processor for plugins.
See more: https://eslint.org/docs/user-guide/configuring/plugins#specifying-processor

It has been added as an optional key to the types,
including inside the `overrides` key.