### PR TITLE
Add RulePatcher with module that fix incorrect interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,14 @@
     "tsconfig.json"
   ],
   "devDependencies": {
+    "@babel/generator": "~7.19.3",
+    "@babel/parser": "~7.19.3",
+    "@babel/traverse": "~7.19.3",
+    "@babel/types": "~7.19.3",
     "@intlify/eslint-plugin-vue-i18n": "~2.0.0",
     "@poppinss/cliui": "~3.0.4",
+    "@types/babel__generator": "~7.6.4",
+    "@types/babel__traverse": "~7.18.2",
     "@types/eslint": "~8.4.6",
     "@types/json-schema": "~7.0.11",
     "@types/node": "~18.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,14 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@babel/generator': ~7.19.3
+  '@babel/parser': ~7.19.3
+  '@babel/traverse': ~7.19.3
+  '@babel/types': ~7.19.3
   '@intlify/eslint-plugin-vue-i18n': ~2.0.0
   '@poppinss/cliui': ~3.0.4
+  '@types/babel__generator': ~7.6.4
+  '@types/babel__traverse': ~7.18.2
   '@types/eslint': ~8.4.6
   '@types/json-schema': ~7.0.11
   '@types/node': ~18.8.2
@@ -36,8 +42,14 @@ specifiers:
   vue-eslint-parser: ~9.1.0
 
 devDependencies:
+  '@babel/generator': 7.19.3
+  '@babel/parser': 7.19.3
+  '@babel/traverse': 7.19.3
+  '@babel/types': 7.19.3
   '@intlify/eslint-plugin-vue-i18n': 2.0.0_eslint@8.24.0
   '@poppinss/cliui': 3.0.4
+  '@types/babel__generator': 7.6.4
+  '@types/babel__traverse': 7.18.2
   '@types/eslint': 8.4.6
   '@types/json-schema': 7.0.11
   '@types/node': 18.8.2
@@ -79,6 +91,47 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
+  /@babel/generator/7.19.3:
+    resolution: {integrity: sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.19.3
+      '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/helper-environment-visitor/7.18.9:
+    resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-function-name/7.19.0:
+    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/types': 7.19.3
+    dev: true
+
+  /@babel/helper-hoist-variables/7.18.6:
+    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.19.3
+    dev: true
+
+  /@babel/helper-split-export-declaration/7.18.6:
+    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.19.3
+    dev: true
+
+  /@babel/helper-string-parser/7.18.10:
+    resolution: {integrity: sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier/7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
@@ -93,11 +146,55 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /@babel/parser/7.19.3:
+    resolution: {integrity: sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.19.3
+    dev: true
+
   /@babel/runtime/7.19.0:
     resolution: {integrity: sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
+    dev: true
+
+  /@babel/template/7.18.10:
+    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.19.3
+      '@babel/types': 7.19.3
+    dev: true
+
+  /@babel/traverse/7.19.3:
+    resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.19.3
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.19.3
+      '@babel/types': 7.19.3
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/types/7.19.3:
+    resolution: {integrity: sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.18.10
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
     dev: true
 
   /@bcherny/json-schema-ref-parser/9.0.9:
@@ -269,6 +366,36 @@ packages:
       '@intlify/shared': 9.2.2
     dev: true
 
+  /@jridgewell/gen-mapping/0.3.2:
+    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.15
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array/1.1.2:
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.15:
+    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
   /@jsdevtools/ono/7.1.3:
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
     dev: true
@@ -329,6 +456,18 @@ packages:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
     dependencies:
       '@types/estree': 1.0.0
+    dev: true
+
+  /@types/babel__generator/7.6.4:
+    resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
+    dependencies:
+      '@babel/types': 7.19.3
+    dev: true
+
+  /@types/babel__traverse/7.18.2:
+    resolution: {integrity: sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==}
+    dependencies:
+      '@babel/types': 7.19.3
     dev: true
 
   /@types/chai-subset/1.3.3:
@@ -2007,6 +2146,11 @@ packages:
       once: 1.4.0
     dev: true
 
+  /globals/11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /globals/13.17.0:
     resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
     engines: {node: '>=8'}
@@ -2351,6 +2495,12 @@ packages:
   /jsdoc-type-pratt-parser/3.1.0:
     resolution: {integrity: sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==}
     engines: {node: '>=12.0.0'}
+    dev: true
+
+  /jsesc/2.5.2:
+    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
+    engines: {node: '>=4'}
+    hasBin: true
     dev: true
 
   /json-parse-even-better-errors/2.3.1:
@@ -3649,6 +3799,11 @@ packages:
   /tinyspy/1.0.2:
     resolution: {integrity: sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==}
     engines: {node: '>=14.0.0'}
+    dev: true
+
+  /to-fast-properties/2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
     dev: true
 
   /to-regex-range/5.0.1:

--- a/scripts/generate-rule-files/contracts/index.ts
+++ b/scripts/generate-rule-files/contracts/index.ts
@@ -1,5 +1,6 @@
 import type { Rule } from 'eslint';
 
+export type MaybePromise<T> = T | Promise<T>;
 export type MaybeArray<T> = T | T[];
 
 export interface Plugin {

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -92,6 +92,7 @@ async function generateRulesFiles(
       ruleName,
       rule,
     );
+
     try {
       await ruleFile.generate();
       ruleFile.writeGeneratedContent();
@@ -129,6 +130,7 @@ function createPluginDirectory(
 export interface RunOptions {
   plugins?: string[];
   targetDirectory?: string;
+  verbose?: boolean;
 }
 
 export async function run(options: RunOptions = {}): Promise<void> {

--- a/scripts/generate-rule-files/src/rule-file.ts
+++ b/scripts/generate-rule-files/src/rule-file.ts
@@ -8,6 +8,7 @@ import type { Plugin } from '../contracts';
 import { format } from './format';
 import { JsDocBuilder } from './js-doc-builder';
 import { generateTypeFromSchema } from './json-schema-to-ts';
+import { defaultRulePatcher } from './rule-patcher';
 
 export class RuleFile {
   private content: string = '';
@@ -191,6 +192,12 @@ export class RuleFile {
     }
   }
 
+  private async applyRulePatcher(): Promise<void> {
+    const rulePatcherResult = await defaultRulePatcher.patch(this.content);
+
+    this.content = rulePatcherResult.fileContent;
+  }
+
   /**
    * Generate a file with the rule typings.
    */
@@ -204,6 +211,7 @@ export class RuleFile {
 
     this.appendRuleConfig();
     this.appendRule();
+    await this.applyRulePatcher();
 
     this.content = format(this.content);
 

--- a/scripts/generate-rule-files/src/rule-patcher/contracts/index.ts
+++ b/scripts/generate-rule-files/src/rule-patcher/contracts/index.ts
@@ -1,0 +1,28 @@
+import type { parse } from '@babel/parser';
+import type { MaybePromise } from '../../../contracts';
+
+export type Ast = ReturnType<typeof parse>;
+
+/**
+ * The result returned by the `patch` method of a module.
+ */
+export type ModulePatchResult = MaybePromise<{
+  hasPatched: boolean;
+  ast: Ast;
+}>;
+
+/**
+ * Type of the report returned by the `patch` method of the `RulePatcher` class.
+ */
+export type RulePatcherReport = {
+  name: string;
+  hasPatched: boolean;
+}[];
+
+/**
+ * Module contract that can be registered withing the RulePatcher.
+ */
+export interface RulePatcherModule {
+  name: string;
+  patch: (parameters: { ast: Ast }) => ModulePatchResult;
+}

--- a/scripts/generate-rule-files/src/rule-patcher/index.ts
+++ b/scripts/generate-rule-files/src/rule-patcher/index.ts
@@ -1,0 +1,73 @@
+import generate from '@babel/generator';
+import { parse } from '@babel/parser';
+import type { Ast, RulePatcherModule, RulePatcherReport } from './contracts';
+import { fixMappedTypes } from './modules/fix-mapped-types';
+
+/**
+ * The RulePatcher is a simple class on which we can register modules that can
+ * modify the AST and generate a new source file to automatically fix some
+ * issues with generated files.
+ */
+export class RulePatcher {
+  private readonly patchers: Set<RulePatcherModule>;
+
+  constructor(patchers: RulePatcherModule[]) {
+    this.patchers = new Set(patchers);
+  }
+
+  /**
+   * Generate an AST from the given source.
+   */
+  private generateAst(source: string): Ast {
+    return parse(source, {
+      sourceType: 'module',
+      plugins: ['typescript'],
+    });
+  }
+
+  private generateSource(ast: Ast): string {
+    // eslint-disable-next-line
+    return generate(ast, { retainLines: true }).code;
+  }
+
+  /**
+   * Register a new module.
+   */
+  public registerModule(patcher: RulePatcherModule): this {
+    this.patchers.add(patcher);
+    return this;
+  }
+
+  /**
+   * Unregister a module.
+   */
+  public unregisterModule(patcher: RulePatcherModule): this {
+    this.patchers.delete(patcher);
+    return this;
+  }
+
+  /**
+   * Apply all registered modules patch to the given source.
+   */
+  public async patch(fileContent: string): Promise<{
+    fileContent: string;
+    report: RulePatcherReport;
+  }> {
+    const report = [];
+    let ast = this.generateAst(fileContent);
+
+    for (const patcher of this.patchers) {
+      const result = await patcher.patch({ ast });
+
+      ast = result.ast;
+      report.push({ name: patcher.name, hasPatched: result.hasPatched });
+    }
+
+    return { fileContent: this.generateSource(ast), report };
+  }
+}
+
+/**
+ * The default rule patcher that includes some common modules
+ */
+export const defaultRulePatcher = new RulePatcher([fixMappedTypes]);

--- a/scripts/generate-rule-files/src/rule-patcher/modules/fix-mapped-types.ts
+++ b/scripts/generate-rule-files/src/rule-patcher/modules/fix-mapped-types.ts
@@ -1,0 +1,119 @@
+import type { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { RulePatcherModule } from '../contracts';
+
+/**
+ * Check if the given interface include a mapped type
+ */
+const isInterfaceIncludingMappedType = (
+  declaration: t.TSInterfaceDeclaration,
+): boolean => {
+  return declaration.body.body.some((member) => t.isTSIndexSignature(member));
+};
+
+/**
+ * Check if the given type include a mapped type
+ */
+const isTypeIncludingMappedType = (type: t.TSTypeLiteral): boolean => {
+  return type.members.some((member) => t.isTSIndexSignature(member));
+};
+
+/**
+ * If the given type include a mapped type, we automatically
+ * extract all the members and create a union with them.
+ */
+const convertMappedTypesToUnion = (type: t.TSTypeLiteral): any => {
+  return t.tsUnionType(type.members.map((member) => t.tsTypeLiteral([member])));
+};
+
+/**
+ * Convert the given interface to a type alias
+ */
+const convertInterfaceToTypeAlias = (
+  path: NodePath<t.TSInterfaceDeclaration>,
+): void => {
+  const newInterface = t.tSTypeAliasDeclaration(
+    path.node.id,
+    null,
+    t.tsTypeLiteral(path.node.body.body),
+  );
+
+  path.replaceWith(newInterface);
+};
+
+/**
+ * Called when a TSTypeAliasDeclaration or TSInterfaceDeclaration is traversed.
+ *
+ * Will create the final union and replace the node with it.
+ */
+const onTypeOrInterfaceFound = (
+  path: NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>,
+): boolean => {
+  if (t.isTSInterfaceDeclaration(path.node)) {
+    convertInterfaceToTypeAlias(path as NodePath<t.TSInterfaceDeclaration>);
+  }
+
+  if (!t.isTSTypeAliasDeclaration(path.node)) {
+    return false;
+  }
+
+  const { node } = path;
+  const { typeAnnotation } = node;
+
+  if (!t.isTSTypeLiteral(typeAnnotation)) {
+    return false;
+  }
+
+  if (!isTypeIncludingMappedType(typeAnnotation)) {
+    return false;
+  }
+
+  const union = convertMappedTypesToUnion(typeAnnotation);
+  path.node.typeAnnotation = union;
+
+  return true;
+};
+
+/**
+ * Convert mapped types that includes another members to an union.
+ *
+ * Example:
+ *
+ * ```
+ * type FileExtensionInImportConfig = {
+ *   tryExtensions?: string[];
+ *   [k: string]: 'always' | 'never';
+ * };
+ * ```
+ *
+ * Would become :
+ * ```
+ * type FileExtensionInImportConfig =
+ *  | { tryExtensions?: string[] }
+ *  | { [k: string]: 'always' | 'never' }
+ * ```
+ *
+ * See #141
+ */
+export const fixMappedTypes: RulePatcherModule = {
+  name: 'fix-mapped-types',
+  patch: ({ ast }) => {
+    let hasPatched = false;
+
+    traverse(ast, {
+      TSTypeAliasDeclaration: (path) => {
+        hasPatched = onTypeOrInterfaceFound(path);
+      },
+      TSInterfaceDeclaration: (path) => {
+        if (!isInterfaceIncludingMappedType(path.node)) {
+          return;
+        }
+
+        hasPatched = onTypeOrInterfaceFound(path);
+      },
+    });
+
+    return { hasPatched, ast };
+  },
+};

--- a/tests/__snapshots__/generate-rule-files.test.ts.snap
+++ b/tests/__snapshots__/generate-rule-files.test.ts.snap
@@ -42,9 +42,9 @@ exports[`Rule File > Object schema 1`] = `
 /**
  * Option.
  */
-export interface MyRuleOption {
+export type MyRuleOption = {
   [k: string]: any;
-}
+};
 
 /**
  * Options.

--- a/tests/rule-patcher.test.ts
+++ b/tests/rule-patcher.test.ts
@@ -51,7 +51,11 @@ describe('Rule patcher', () => {
       console.log('lets go')
     `);
 
-    expect(result.fileContent).toBe("console.log('lets go');");
+    expect(result.fileContent).toMatchInlineSnapshot(`
+      "
+
+      console.log('lets go');"
+    `);
     expect(getReportOf(result.report, 'test').hasPatched).toBe(true);
   });
 });
@@ -66,11 +70,10 @@ describe('Fix mapped types module', () => {
     `);
 
     expect(result.fileContent).toMatchInlineSnapshot(`
-      "type FileExtensionInImportConfig = {
-        tryExtensions?: string[];
-      } | {
-        [k: string]: 'always' | 'never';
-      };"
+      "
+      type FileExtensionInImportConfig = {
+        tryExtensions?: string[];} | {
+        [k: string]: 'always' | 'never';};"
     `);
 
     expect(getReportOf(result.report, 'fix-mapped-types').hasPatched).toBe(
@@ -87,11 +90,10 @@ describe('Fix mapped types module', () => {
     `);
 
     expect(result.fileContent).toMatchInlineSnapshot(`
-      "export type FileExtensionInImportConfig = {
-        tryExtensions?: string[];
-      } | {
-        [k: string]: 'always' | 'never';
-      };"
+      "
+      export type FileExtensionInImportConfig = {
+        tryExtensions?: string[];} | {
+        [k: string]: 'always' | 'never';};"
     `);
   });
 

--- a/tests/rule-patcher.test.ts
+++ b/tests/rule-patcher.test.ts
@@ -95,7 +95,7 @@ describe('Fix mapped types module', () => {
     `);
   });
 
-  it.only('Should works with interface', async () => {
+  it('Should works with interface', async () => {
     const result = await new RulePatcher([fixMappedTypes]).patch(`
       export interface FileExtensionInImportConfig {
         tryExtensions?: string[];

--- a/tests/rule-patcher.test.ts
+++ b/tests/rule-patcher.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { RulePatcher } from '../scripts/generate-rule-files/src/rule-patcher';
+import type {
+  RulePatcherModule,
+  RulePatcherReport,
+} from '../scripts/generate-rule-files/src/rule-patcher/contracts';
+import { fixMappedTypes } from '../scripts/generate-rule-files/src/rule-patcher/modules/fix-mapped-types';
+
+const getReportOf = (
+  report: RulePatcherReport,
+  name: string,
+): RulePatcherReport[number] => report.find((item) => item.name === name)!;
+
+describe('Rule patcher', () => {
+  it('Should set hasPatched', async () => {
+    const rulePatcherModule: RulePatcherModule = {
+      name: 'test',
+      patch: ({ ast }) => ({ ast, hasPatched: true }),
+    };
+
+    const result = await new RulePatcher([rulePatcherModule]).patch('');
+    expect(getReportOf(result.report, 'test').hasPatched).toBe(true);
+  });
+
+  it('Should generate new source from modified ast', async () => {
+    const rulePatcherModule: RulePatcherModule = {
+      name: 'test',
+      patch: ({ ast }) => {
+        const newBody = ast.program.body
+          .map((node) => {
+            if (node.type === 'ExportNamedDeclaration') {
+              return null;
+            }
+
+            return node;
+          })
+          .filter(Boolean) as typeof ast.program.body;
+
+        return {
+          ast: {
+            ...ast,
+            program: { ...ast.program, body: newBody },
+          },
+          hasPatched: true,
+        };
+      },
+    };
+
+    const result = await new RulePatcher([rulePatcherModule]).patch(`
+      export const a = 42
+      console.log('lets go')
+    `);
+
+    expect(result.fileContent).toBe("console.log('lets go');");
+    expect(getReportOf(result.report, 'test').hasPatched).toBe(true);
+  });
+});
+
+describe('Fix mapped types module', () => {
+  it('Should fix wrong mapped types', async () => {
+    const result = await new RulePatcher([fixMappedTypes]).patch(`
+      type FileExtensionInImportConfig = {
+        tryExtensions?: string[];
+        [k: string]: 'always' | 'never';
+      };
+    `);
+
+    expect(result.fileContent).toMatchInlineSnapshot(`
+      "type FileExtensionInImportConfig = {
+        tryExtensions?: string[];
+      } | {
+        [k: string]: 'always' | 'never';
+      };"
+    `);
+
+    expect(getReportOf(result.report, 'fix-mapped-types').hasPatched).toBe(
+      true,
+    );
+  });
+
+  it('Should works if type is exported', async () => {
+    const result = await new RulePatcher([fixMappedTypes]).patch(`
+      export type FileExtensionInImportConfig = {
+        tryExtensions?: string[];
+        [k: string]: 'always' | 'never';
+      };
+    `);
+
+    expect(result.fileContent).toMatchInlineSnapshot(`
+      "export type FileExtensionInImportConfig = {
+        tryExtensions?: string[];
+      } | {
+        [k: string]: 'always' | 'never';
+      };"
+    `);
+  });
+
+  it.only('Should works with interface', async () => {
+    const result = await new RulePatcher([fixMappedTypes]).patch(`
+      export interface FileExtensionInImportConfig {
+        tryExtensions?: string[];
+        [k: string]: 'always' | 'never';
+      };
+    `);
+
+    expect(result.fileContent).toMatchInlineSnapshot(`
+      "
+      export type FileExtensionInImportConfig = {
+        tryExtensions?: string[];} | {
+        [k: string]: 'always' | 'never';};
+      ;"
+    `);
+  });
+});


### PR DESCRIPTION
Closes #141 

Yo 

Here is my attempt at what we were discussing in this issue 

So we have the `RulePatcher` class, which is just a kind of container on which we will register modules. These said modules will be applied at the end of the rule file generation. Each of these modules will have access to the AST of the generated file, and can modify it. Once all the modules have been applied, the source code is generated from this modified ast. 

I have implemented a first module that simply converts the mapped types and interface into a union with the different members.
And it works great for the `node/file-extension-in-import` rule

The only thing that is problematic is the following: 
I use @babel/generator to regenerate the source code, and : 
> Note: The symbols like white spaces or new line characters are not preserved in the AST. When Babel generator prints code from the AST, the output format is not guaranteed.
https://babeljs.io/docs/en/babel-generator

I used the `retainLines` options which allows having something formatted more or less like before.

But we still end up with ~50 diff files compared to the original rules which have extra spaces in some places.

Example : 
![image](https://user-images.githubusercontent.com/8337858/193947963-eb788887-4bf0-4f3b-bda0-709e5c37a1e5.png)

But it's not a big deal in my opinion.

The other thing I miss is to display the number of patches applied in the terminal report. Everything is ready thanks to the `hasPatched` property, it's just missing basically the console.log. But now I'm going to bed 😋

Let me know if anything is wrong