### PR TITLE
fix(overrides): add missing `globals` key

### DIFF
--- a/src/config/overrides.d.ts
+++ b/src/config/overrides.d.ts
@@ -28,6 +28,16 @@ export interface Override {
   extends?: Extends;
 
   /**
+   * Specifying Globals.
+   *
+   * @see [Globals](https://ESLint.org/docs/user-guide/configuring/language-options#specifying-globals)
+   */
+  globals?: Record<
+    string,
+    'readonly' | 'writable' | false | 'readable' | true | 'writeable' | 'off'
+  >;
+
+  /**
    * Parser.
    *
    * @see [Working with Custom Parsers](https://eslint.org/docs/developer-guide/working-with-custom-parsers)


### PR DESCRIPTION
Hello,

Global variables can be defined within override blocks, this PR aims to fix the issue.

I've tested it inside the repo:
![image](https://user-images.githubusercontent.com/31937175/200639722-fc6f5a31-4a60-4020-80dc-6dcf2cc37c5d.png)

![image](https://user-images.githubusercontent.com/31937175/200639278-4e7122b3-e2e9-4c0c-bca8-4bceb1d4ec88.png)

