### PR TITLE
Patch rule files automatically

### DIFF
--- a/scripts/generate-rule-files/diffs/rules/eslint/no-constructor-return.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/eslint/no-constructor-return.d.ts.diff
@@ -1,0 +1,22 @@
+diff --git b/src/rules/eslint/no-constructor-return.d.ts a/src/rules/eslint/no-constructor-return.d.ts
+index fedeca4..3e1fd03 100644
+--- b/src/rules/eslint/no-constructor-return.d.ts
++++ a/src/rules/eslint/no-constructor-return.d.ts
+@@ -1,16 +1,9 @@
+ import type { RuleConfig } from '../rule-config';
+ 
+-/**
+- * Option.
+- */
+-export interface NoConstructorReturnOption {
+-  [k: string]: any;
+-}
+-
+ /**
+  * Options.
+  */
+-export type NoConstructorReturnOptions = NoConstructorReturnOption;
++export type NoConstructorReturnOptions = [];
+ 
+ /**
+  * Disallow returning value from constructor.

--- a/scripts/generate-rule-files/diffs/rules/graphql-eslint/naming-convention.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/graphql-eslint/naming-convention.d.ts.diff
@@ -1,0 +1,14 @@
+diff --git b/src/rules/graphql-eslint/naming-convention.d.ts a/src/rules/graphql-eslint/naming-convention.d.ts
+index 60b228b..5e01373 100644
+--- b/src/rules/graphql-eslint/naming-convention.d.ts
++++ a/src/rules/graphql-eslint/naming-convention.d.ts
+@@ -78,8 +78,7 @@ export type NamingConventionOption =
+         VariableDefinition?: AsString | AsObject;
+         allowLeadingUnderscore?: boolean;
+         allowTrailingUnderscore?: boolean;
+-        /**
+-         */
++      } & {
+         [k: string]: AsString | AsObject;
+       },
+     ];

--- a/scripts/generate-rule-files/diffs/rules/node/file-extension-in-import.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/node/file-extension-in-import.d.ts.diff
@@ -1,0 +1,13 @@
+diff --git b/src/rules/node/file-extension-in-import.d.ts a/src/rules/node/file-extension-in-import.d.ts
+index 652b18d..7261252 100644
+--- b/src/rules/node/file-extension-in-import.d.ts
++++ a/src/rules/node/file-extension-in-import.d.ts
+@@ -5,7 +5,7 @@ import type { RuleConfig } from '../rule-config';
+  */
+ export interface FileExtensionInImportConfig {
+   tryExtensions?: string[];
+-  [k: string]: 'always' | 'never';
++  [ext: `.${string}`]: 'always' | 'never';
+ }
+ 
+ /**

--- a/scripts/generate-rule-files/diffs/rules/typescript-eslint/array-type.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/typescript-eslint/array-type.d.ts.diff
@@ -1,0 +1,23 @@
+diff --git b/src/rules/typescript-eslint/array-type.d.ts a/src/rules/typescript-eslint/array-type.d.ts
+index 98cd312..fe661fc 100644
+--- b/src/rules/typescript-eslint/array-type.d.ts
++++ a/src/rules/typescript-eslint/array-type.d.ts
+@@ -3,12 +3,16 @@ import type { RuleConfig } from '../rule-config';
+ /**
+  * Option.
+  */
+-export type ArrayTypeOption = any[];
++export interface ArrayTypeOption {
++  default?: 'array' | 'generic' | 'array-simple';
++  readonly?: 'array' | 'generic' | 'array-simple';
++  [k: string]: any;
++}
+ 
+ /**
+  * Options.
+  */
+-export type ArrayTypeOptions = ArrayTypeOption;
++export type ArrayTypeOptions = [ArrayTypeOption?];
+ 
+ /**
+  * Require consistently using either `T[]` or `Array<T>` for arrays.

--- a/scripts/generate-rule-files/diffs/rules/typescript-eslint/ban-ts-comment.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/typescript-eslint/ban-ts-comment.d.ts.diff
@@ -1,0 +1,49 @@
+diff --git b/src/rules/typescript-eslint/ban-ts-comment.d.ts a/src/rules/typescript-eslint/ban-ts-comment.d.ts
+index 111f9c9..5d489f8 100644
+--- b/src/rules/typescript-eslint/ban-ts-comment.d.ts
++++ a/src/rules/typescript-eslint/ban-ts-comment.d.ts
+@@ -3,12 +3,42 @@ import type { RuleConfig } from '../rule-config';
+ /**
+  * Option.
+  */
+-export type BanTsCommentOption = any[];
++export interface BanTsCommentOption {
++  'ts-expect-error'?:
++    | boolean
++    | 'allow-with-description'
++    | {
++        descriptionFormat?: string;
++        [k: string]: any;
++      };
++  'ts-ignore'?:
++    | boolean
++    | 'allow-with-description'
++    | {
++        descriptionFormat?: string;
++        [k: string]: any;
++      };
++  'ts-nocheck'?:
++    | boolean
++    | 'allow-with-description'
++    | {
++        descriptionFormat?: string;
++        [k: string]: any;
++      };
++  'ts-check'?:
++    | boolean
++    | 'allow-with-description'
++    | {
++        descriptionFormat?: string;
++        [k: string]: any;
++      };
++  minimumDescriptionLength?: number;
++}
+ 
+ /**
+  * Options.
+  */
+-export type BanTsCommentOptions = BanTsCommentOption;
++export type BanTsCommentOptions = [BanTsCommentOption?];
+ 
+ /**
+  * Disallow `@ts-<directive>` comments or require descriptions after directives.

--- a/scripts/generate-rule-files/diffs/rules/typescript-eslint/explicit-member-accessibility.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/typescript-eslint/explicit-member-accessibility.d.ts.diff
@@ -1,0 +1,32 @@
+diff --git b/src/rules/typescript-eslint/explicit-member-accessibility.d.ts a/src/rules/typescript-eslint/explicit-member-accessibility.d.ts
+index b585e26..1711d51 100644
+--- b/src/rules/typescript-eslint/explicit-member-accessibility.d.ts
++++ a/src/rules/typescript-eslint/explicit-member-accessibility.d.ts
+@@ -3,13 +3,24 @@ import type { RuleConfig } from '../rule-config';
+ /**
+  * Option.
+  */
+-export type ExplicitMemberAccessibilityOption = any[];
++export interface ExplicitMemberAccessibilityOption {
++  accessibility?: 'explicit' | 'no-public' | 'off';
++  overrides?: {
++    accessors?: 'explicit' | 'no-public' | 'off';
++    constructors?: 'explicit' | 'no-public' | 'off';
++    methods?: 'explicit' | 'no-public' | 'off';
++    properties?: 'explicit' | 'no-public' | 'off';
++    parameterProperties?: 'explicit' | 'no-public' | 'off';
++  };
++  ignoredMethodNames?: string[];
++}
+ 
+ /**
+  * Options.
+  */
+-export type ExplicitMemberAccessibilityOptions =
+-  ExplicitMemberAccessibilityOption;
++export type ExplicitMemberAccessibilityOptions = [
++  ExplicitMemberAccessibilityOption?,
++];
+ 
+ /**
+  * Require explicit accessibility modifiers on class properties and methods.

--- a/scripts/generate-rule-files/diffs/rules/typescript-eslint/lines-between-class-members.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/typescript-eslint/lines-between-class-members.d.ts.diff
@@ -1,0 +1,32 @@
+diff --git b/src/rules/typescript-eslint/lines-between-class-members.d.ts a/src/rules/typescript-eslint/lines-between-class-members.d.ts
+index 46caad7..afdd87e 100644
+--- b/src/rules/typescript-eslint/lines-between-class-members.d.ts
++++ a/src/rules/typescript-eslint/lines-between-class-members.d.ts
+@@ -1,16 +1,23 @@
++import type {
++  LinesBetweenClassMembersConfig as BaseConfig,
++  LinesBetweenClassMembersOption,
++} from '../eslint/lines-between-class-members';
+ import type { RuleConfig } from '../rule-config';
+ 
+ /**
+- * Option.
++ * Config.
+  */
+-export interface LinesBetweenClassMembersOption {
+-  [k: string]: any;
++export interface LinesBetweenClassMembersConfig extends BaseConfig {
++  exceptAfterOverload?: boolean;
+ }
+ 
+ /**
+  * Options.
+  */
+-export type LinesBetweenClassMembersOptions = LinesBetweenClassMembersOption;
++export type LinesBetweenClassMembersOptions = [
++  LinesBetweenClassMembersOption?,
++  LinesBetweenClassMembersConfig?,
++];
+ 
+ /**
+  * Require or disallow an empty line between class members.

--- a/scripts/generate-rule-files/diffs/rules/typescript-eslint/parameter-properties.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/typescript-eslint/parameter-properties.d.ts.diff
@@ -1,0 +1,44 @@
+diff --git b/src/rules/typescript-eslint/parameter-properties.d.ts a/src/rules/typescript-eslint/parameter-properties.d.ts
+index 6b0f176..591a9a4 100644
+--- b/src/rules/typescript-eslint/parameter-properties.d.ts
++++ a/src/rules/typescript-eslint/parameter-properties.d.ts
+@@ -3,12 +3,37 @@ import type { RuleConfig } from '../rule-config';
+ /**
+  * Option.
+  */
+-export type ParameterPropertiesOption = any[];
++export interface ParameterPropertiesOption {
++  /**
++   * @minItems 1
++   */
++  allow?: [
++    (
++      | 'readonly'
++      | 'private'
++      | 'protected'
++      | 'public'
++      | 'private readonly'
++      | 'protected readonly'
++      | 'public readonly'
++    ),
++    ...(
++      | 'readonly'
++      | 'private'
++      | 'protected'
++      | 'public'
++      | 'private readonly'
++      | 'protected readonly'
++      | 'public readonly'
++    )[],
++  ];
++  prefer?: 'class-property' | 'parameter-property';
++}
+ 
+ /**
+  * Options.
+  */
+-export type ParameterPropertiesOptions = ParameterPropertiesOption;
++export type ParameterPropertiesOptions = [ParameterPropertiesOption?];
+ 
+ /**
+  * Require or disallow parameter properties in class constructors.

--- a/scripts/generate-rule-files/diffs/rules/unicorn/import-index.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/unicorn/import-index.d.ts.diff
@@ -1,0 +1,58 @@
+diff --git b/src/rules/unicorn/import-index.d.ts a/src/rules/unicorn/import-index.d.ts
+index a1ce37b..41805a7 100644
+--- b/src/rules/unicorn/import-index.d.ts
++++ a/src/rules/unicorn/import-index.d.ts
+@@ -1,25 +1,49 @@
+ import type { RuleConfig } from '../rule-config';
+ 
+ /**
++ * Option.
++ *
++ * @deprecated
++ */
++export interface ImportIndexOption {
++  /**
++   * @deprecated
++   */
++  ignoreImports?: boolean;
++}
++
++/**
++ * Options.
++ *
++ * @deprecated
++ *
++ * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v43.0.2/docs/deprecated-rules.md#import-index)
++ */
++export type ImportIndexOptions = [ImportIndexOption?];
++
++/**
++ * Enforce importing index files with `.`.
+  *
+  * @deprecated
+  *
+- * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v46.0.0/docs/deprecated-rules.md#import-index)
++ * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v42.0.0/docs/rules/import-index.md)
+  */
+-export type ImportIndexRuleConfig = RuleConfig<[]>;
++export type ImportIndexRuleConfig = RuleConfig<ImportIndexOptions>;
+ 
+ /**
++ * Enforce importing index files with `.`.
+  *
+  * @deprecated
+  *
+- * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v46.0.0/docs/deprecated-rules.md#import-index)
++ * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v43.0.2/docs/deprecated-rules.md#import-index)
+  */
+ export interface ImportIndexRule {
+   /**
++   * Enforce importing index files with `.`.
+    *
+    * @deprecated
+    *
+-   * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v46.0.0/docs/deprecated-rules.md#import-index)
++   * @see [import-index](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v43.0.2/docs/deprecated-rules.md#import-index)
+    */
+   'unicorn/import-index': ImportIndexRuleConfig;
+ }

--- a/scripts/generate-rule-files/diffs/rules/unicorn/prefer-node-protocol.d.ts.diff
+++ b/scripts/generate-rule-files/diffs/rules/unicorn/prefer-node-protocol.d.ts.diff
@@ -1,0 +1,51 @@
+diff --git b/src/rules/unicorn/prefer-node-protocol.d.ts a/src/rules/unicorn/prefer-node-protocol.d.ts
+index 74279c2..a7e17b8 100644
+--- b/src/rules/unicorn/prefer-node-protocol.d.ts
++++ a/src/rules/unicorn/prefer-node-protocol.d.ts
+@@ -1,22 +1,42 @@
+ import type { RuleConfig } from '../rule-config';
+ 
++/**
++ * Option.
++ *
++ * @deprecated
++ */
++export interface PreferNodeProtocolOption {
++  /**
++   * @deprecated
++   */
++  checkRequire?: boolean;
++}
++
++/**
++ * Options.
++ *
++ * @deprecated
++ */
++export type PreferNodeProtocolOptions = [PreferNodeProtocolOption?];
++
+ /**
+  * Prefer using the `node:` protocol when importing Node.js builtin modules.
+  *
+- * @see [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v46.0.0/docs/rules/prefer-node-protocol.md)
++ * @see [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v44.0.2/docs/rules/prefer-node-protocol.md)
+  */
+-export type PreferNodeProtocolRuleConfig = RuleConfig<[]>;
++export type PreferNodeProtocolRuleConfig =
++  RuleConfig<PreferNodeProtocolOptions>;
+ 
+ /**
+  * Prefer using the `node:` protocol when importing Node.js builtin modules.
+  *
+- * @see [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v46.0.0/docs/rules/prefer-node-protocol.md)
++ * @see [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v44.0.2/docs/rules/prefer-node-protocol.md)
+  */
+ export interface PreferNodeProtocolRule {
+   /**
+    * Prefer using the `node:` protocol when importing Node.js builtin modules.
+    *
+-   * @see [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v46.0.0/docs/rules/prefer-node-protocol.md)
++   * @see [prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v44.0.2/docs/rules/prefer-node-protocol.md)
+    */
+   'unicorn/prefer-node-protocol': PreferNodeProtocolRuleConfig;
+ }

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -95,6 +95,7 @@ async function generateRulesFiles(
     try {
       await ruleFile.generate();
       ruleFile.writeGeneratedContent();
+      ruleFile.applyPatch();
     } catch (err) {
       failedRules.push(ruleName);
     }


### PR DESCRIPTION
Running `pnpm run generate:rules` results in some files that are invalid
We can run `git diff -R src/rules/<plugin>/<rule>.d.ts > scripts/generate-rule-files/diffs/rules/<plugin>/<rule>.d.ts.diff` to generate a diff file that reverts what is invalid