### PR TITLE
Write errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "prepublishOnly": "pnpm run clean && pnpm install && pnpm run check",
+    "generate:diffs": "tsx ./scripts/generate-diffs.ts",
     "generate:rules": "tsx ./scripts/generate-rule-files/cli.ts"
   },
   "keywords": [

--- a/scripts/generate-diffs.ts
+++ b/scripts/generate-diffs.ts
@@ -1,0 +1,12 @@
+import { execSync } from 'node:child_process';
+const changes: string[] = execSync('git diff --name-only --staged', {
+  encoding: 'utf-8',
+}).split('\n');
+
+const rules: string[] = changes.filter((c) => c.startsWith('src/rules/'));
+console.log(rules);
+
+for (const rule of rules) {
+  const diffPath: string = `scripts/generate-rule-files/diffs/${rule.slice(4)}`;
+  execSync(`git diff --staged ${rule} > ${diffPath}.diff`);
+}

--- a/scripts/generate-diffs.ts
+++ b/scripts/generate-diffs.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
 
 const changes: string[] = execSync('git diff --name-only --staged', {
   encoding: 'utf-8',
@@ -11,6 +12,14 @@ const rules: string[] = changes.filter((change) =>
 console.log(rules);
 
 for (const rule of rules) {
+  const dir: string = `scripts/generate-rule-files/diffs/${rule
+    .slice(4)
+    .replace(/\/[^/]*$/, '')}`;
+  console.log({ dir });
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
   const diffPath: string = `scripts/generate-rule-files/diffs/${rule.slice(4)}`;
   execSync(`git diff --staged ${rule} > ${diffPath}.diff`);
 }

--- a/scripts/generate-diffs.ts
+++ b/scripts/generate-diffs.ts
@@ -1,9 +1,13 @@
 import { execSync } from 'node:child_process';
+
 const changes: string[] = execSync('git diff --name-only --staged', {
   encoding: 'utf-8',
 }).split('\n');
 
-const rules: string[] = changes.filter((c) => c.startsWith('src/rules/'));
+const rules: string[] = changes.filter((change) =>
+  change.startsWith('src/rules/'),
+);
+
 console.log(rules);
 
 for (const rule of rules) {

--- a/scripts/generate-rule-files/cli.ts
+++ b/scripts/generate-rule-files/cli.ts
@@ -6,4 +6,12 @@ const selectedPlugins: string[] | undefined = process.argv
   ?.replace('--plugins=', '')
   .split(',');
 
-run({ plugins: selectedPlugins }).catch((err) => console.error(err));
+const debuggedRules: string[] | undefined = process.argv
+  .slice(2)
+  .find((arg) => arg.startsWith('--debug='))
+  ?.replace('--debug=', '')
+  .split(',');
+
+run({ plugins: selectedPlugins, debuggedRules }).catch((err) =>
+  console.error(err),
+);

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -158,6 +158,8 @@ export async function run(options: RunOptions = {}): Promise<void> {
     }
 
     logger.info(`Generating ${plugin.name} rules.`);
+    logger.logUpdate(logger.colors.yellow('  Loading plugin > Prettier'));
+    format('');
     logger.logUpdate(
       logger.colors.yellow(`  Loading plugin > ${plugin.module}`),
     );

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -85,6 +85,7 @@ function printGenerationReport(
 async function generateRulesFiles(
   plugin: Plugin,
   pluginDirectory: string,
+  debuggedRules?: string[],
 ): Promise<{ failedRules: string[] }> {
   const failedRules: string[] = [];
 
@@ -103,19 +104,25 @@ async function generateRulesFiles(
       ruleName,
       rule,
     );
-    logger.logUpdate(
-      logger.colors.yellow(`  Generating > ${ruleFile.prefixedRuleName()}`),
-    );
+    const prefixedName: string = ruleFile.prefixedRuleName();
+
+    logger.logUpdate(logger.colors.yellow(`  Generating > ${prefixedName}`));
     try {
       await ruleFile.generate();
       ruleFile.writeGeneratedContent();
       ruleFile.applyPatch();
+
+      if (debuggedRules?.some((target) => prefixedName.includes(target))) {
+        logger.logUpdate(
+          `  🐞 Debugging ${ruleName}: see ${ruleFile.errorFilePath()}`,
+        );
+        logger.logUpdatePersist();
+        ruleFile.writeGeneratedError(new Error('The rule is being debugged'));
+      }
     } catch (err) {
       ruleFile.writeGeneratedError(err as Error);
       logger.logUpdate(
-        logger.colors.red(
-          `     ❌ Failed to generate ${ruleFile.prefixedRuleName()}`,
-        ),
+        logger.colors.red(`     ❌ Failed to generate ${prefixedName}`),
       );
       logger.logUpdatePersist();
       failedRules.push(ruleName);
@@ -152,6 +159,7 @@ function createPluginDirectory(
 export interface RunOptions {
   plugins?: string[];
   targetDirectory?: string;
+  debuggedRules?: string[];
 }
 
 export async function run(options: RunOptions = {}): Promise<void> {
@@ -177,7 +185,11 @@ export async function run(options: RunOptions = {}): Promise<void> {
       pluginName,
       targetDirectory,
     );
-    const { failedRules } = await generateRulesFiles(loadedPlugin, pluginDir);
+    const { failedRules } = await generateRulesFiles(
+      loadedPlugin,
+      pluginDir,
+      options.debuggedRules,
+    );
 
     generateRuleIndexFile(pluginDir, loadedPlugin, failedRules);
   }

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -167,7 +167,7 @@ export async function run(options: RunOptions = {}): Promise<void> {
 
     logger.info(`Generating ${plugin.name} rules.`);
     logger.logUpdate(logger.colors.yellow('  Loading plugin > Prettier'));
-    format('');
+    format(''); // Run Prettier on empty input to avoid cold start
     logger.logUpdate(
       logger.colors.yellow(`  Loading plugin > ${plugin.module}`),
     );

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -97,19 +97,27 @@ async function generateRulesFiles(
 
   const rules: Array<[string, Rule.RuleModule]> = Object.entries(pluginRules);
   for (const [ruleName, rule] of rules) {
-    logger.logUpdate(logger.colors.yellow(`  Generating > ${ruleName}`));
-
     const ruleFile: RuleFile = new RuleFile(
       plugin,
       pluginDirectory,
       ruleName,
       rule,
     );
+    logger.logUpdate(
+      logger.colors.yellow(`  Generating > ${ruleFile.prefixedRuleName()}`),
+    );
     try {
       await ruleFile.generate();
       ruleFile.writeGeneratedContent();
       ruleFile.applyPatch();
     } catch (err) {
+      ruleFile.writeGeneratedError(err as Error);
+      logger.logUpdate(
+        logger.colors.red(
+          `     ❌ Failed to generate ${ruleFile.prefixedRuleName()}`,
+        ),
+      );
+      logger.logUpdatePersist();
       failedRules.push(ruleName);
     }
   }

--- a/scripts/generate-rule-files/index.ts
+++ b/scripts/generate-rule-files/index.ts
@@ -38,9 +38,8 @@ function generateRuleIndexFile(
   /**
    * Build the exported type that is an intersection of all the rules.
    */
-  const rulesFinalIntersection: string = generatedRules
-    .map((name) => `${pascalCase(name)}Rule`)
-    .join(' & ');
+  const rulesFinalIntersection: string =
+    generatedRules.map((name) => `${pascalCase(name)}Rule`).join(' & ') || '{}';
 
   const pluginRulesType: string = dedent(`
     ${JsDocBuilder.build().add(`All ${name} rules.`).output()}

--- a/scripts/generate-rule-files/src/rule-file.ts
+++ b/scripts/generate-rule-files/src/rule-file.ts
@@ -167,7 +167,7 @@ export class RuleFile {
   /**
    * Scoped rule name ESLint config uses.
    */
-  private prefixedRuleName(): string {
+  public prefixedRuleName(): string {
     const { prefix, name } = this.plugin;
     let rulePrefix: string = (prefix ?? kebabCase(name)) + '/';
 
@@ -221,6 +221,9 @@ export class RuleFile {
     return this.content;
   }
 
+  public errorFilePath(): string {
+    return this.rulePath.replace(/.d.ts$/, '.error.d.ts');
+  }
   /**
    * Must be called after `generate()` to write the file.
    */
@@ -228,6 +231,28 @@ export class RuleFile {
     this.createRuleDirectory();
 
     writeFileSync(this.rulePath, this.content);
+  }
+  /**
+   * Must be called after `generate()` to write the error.
+   */
+  public writeGeneratedError(error: Error): void {
+    this.createRuleDirectory();
+    const errorText: string = error.toString().trimEnd().replace(/^/gm, ' * ');
+    const { isSchemaArray, mainSchema, sideSchema, thirdSchema } = this;
+    const context: string = JSON.stringify(
+      {
+        isSchemaArray,
+        mainSchema,
+        sideSchema,
+        thirdSchema,
+      },
+      null,
+      '  ',
+    );
+    writeFileSync(
+      this.errorFilePath(),
+      `/**\n${errorText}\n */\n\n${this.content}\n\n\nexport const context: ${context}`,
+    );
   }
 
   /**

--- a/scripts/generate-rule-files/src/rule-file.ts
+++ b/scripts/generate-rule-files/src/rule-file.ts
@@ -224,6 +224,7 @@ export class RuleFile {
   public errorFilePath(): string {
     return this.rulePath.replace(/.d.ts$/, '.error.d.ts');
   }
+
   /**
    * Must be called after `generate()` to write the file.
    */
@@ -232,6 +233,7 @@ export class RuleFile {
 
     writeFileSync(this.rulePath, this.content);
   }
+
   /**
    * Must be called after `generate()` to write the error.
    */

--- a/scripts/generate-rule-files/src/rule-file.ts
+++ b/scripts/generate-rule-files/src/rule-file.ts
@@ -236,7 +236,7 @@ export class RuleFile {
    * Must be called after `generate()`.
    */
   public applyPatch(): void {
-    const pathParts: string[] = this.rulePath.split('/');
+    const pathParts: string[] = this.rulePath.split(/[\\/]/);
     const ruleFileName: string = pathParts[pathParts.length - 1] ?? '';
     const rulePlugin: string = pathParts[pathParts.length - 2] ?? '';
 


### PR DESCRIPTION
#177 initially causes many files to error, leading to need of ability to easily view what, where and why have errored.

This PR makes errored generations write `<rule>.error.d.ts` with Error message, generation result and used schema
Also fixes some minor things

This was split off #177