### PR TITLE
feat: new Vue 3.3 macros `defineOptions`, `defineSlots`

### DIFF
--- a/src/rules/vue/define-macros-order.d.ts
+++ b/src/rules/vue/define-macros-order.d.ts
@@ -4,7 +4,7 @@ import type { RuleConfig } from '../rule-config';
  * Option.
  */
 export interface DefineMacrosOrderOption {
-  order?: ('defineEmits' | 'defineProps')[];
+  order?: ('defineEmits' | 'defineProps' | 'defineOptions' | 'defineSlots')[];
 }
 
 /**


### PR DESCRIPTION
Add support for new Vue 3.3 macros - `defineOptions`, and `defineSlots`.
[eslint-plugin-vue docs](https://eslint.vuejs.org/rules/define-macros-order.html#order-defineoptions-defineprops-defineemits-defineslots)