### PR TITLE
Fix incorrect definitions for react/require-default-props

### DIFF
--- a/src/rules/react/require-default-props.d.ts
+++ b/src/rules/react/require-default-props.d.ts
@@ -5,12 +5,9 @@ import type { RuleConfig } from '../rule-config';
  */
 export interface RequireDefaultPropsOption {
   forbidDefaultForRequired?: boolean;
-  classes?: {
-    [k: string]: any;
-  };
-  functions?: {
-    [k: string]: any;
-  };
+  classes?: 'defaultProps' | 'ignore';
+  functions?: 'defaultProps' | 'defaultArguments' | 'ignore';
+  /** @deprecated Use `functions` option instead. */
   ignoreFunctionalComponents?: boolean;
 }
 


### PR DESCRIPTION
See the [documentation](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md#rule-options) for this rule’s options. 

Neither the `classes` option nor the `functions` option accepts an object value, so the previous type definition here is incorrect and broken.

Example of correctly written eslint config being assigned an erroneous type error:

<img width="714" alt="config-error" src="https://github.com/Shinigami92/eslint-define-config/assets/10377391/90fadfd9-8bf1-4b4a-996d-41d046e05391">

<p>&nbsp;</p>

I also added a `@deprecated` label for the option that is listed as such in the documentation.