### PR TITLE
Update type for typescript-eslint/prefer-nullish-coalescing

### DIFF
--- a/src/rules/typescript-eslint/prefer-nullish-coalescing.d.ts
+++ b/src/rules/typescript-eslint/prefer-nullish-coalescing.d.ts
@@ -4,10 +4,17 @@ import type { RuleConfig } from '../rule-config';
  * Option.
  */
 export interface PreferNullishCoalescingOption {
-  ignoreConditionalTests?: boolean;
-  ignoreTernaryTests?: boolean;
-  ignoreMixedLogicalExpressions?: boolean;
   allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
+  ignoreConditionalTests?: boolean;
+  ignoreMixedLogicalExpressions?: boolean;
+  ignorePrimitives?: {
+    bigint?: boolean;
+    boolean?: boolean;
+    number?: boolean;
+    string?: boolean;
+    [k: string]: unknown;
+  };
+  ignoreTernaryTests?: boolean;
 }
 
 /**


### PR DESCRIPTION
Copied the latest type definition from https://typescript-eslint.io/rules/prefer-nullish-coalescing/

Adds the `ignorePrimitives` option, which was [added recently](https://github.com/typescript-eslint/typescript-eslint/pull/6487)